### PR TITLE
Fixes issue caused by memoizing tubular api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "tubular-react-common",
-    "version": "3.0.0-beta",
+    "version": "0.0.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/useTubular.ts
+++ b/src/useTubular.ts
@@ -220,7 +220,7 @@ export const useTubular = (
 
     const tbInstance = {
         state: tbState,
-        api: React.useMemo(() => api, []),
+        api,
     };
 
     return tbInstance;


### PR DESCRIPTION
Previously I made a mistake by trying to memoized tubular api without providing proper dependencies. I'm rolling back that change from the previous version while I find another way to improve performance on that.