### PR TITLE
Using different method to force refresh

### DIFF
--- a/src/useTubular.ts
+++ b/src/useTubular.ts
@@ -58,7 +58,9 @@ export const useTubular = (
         searchText: searchText || '',
     });
     const [getStorage] = React.useState<DataGridStorage>(initStorage);
-    const [refresh, forceRefresh] = useGridRefresh();
+    const [refresh, setRefresh] = React.useState(0);
+    const forceRefresh = () => setRefresh((refresh) => refresh + 1);
+
     const getAllRecords = React.useCallback(() => {
         return source instanceof Array ? getLocalDataSource(source) : getRemoteDataSource(source);
     }, [source]);


### PR DESCRIPTION
Seems that previous implementation is creating a closure for some scenarios.

I did some tests and tried multiple times with several approaches and this was the only way I was able to make the reloadGrid method work properly.