### PR TITLE
Search and Changes on columns will cause resetting page. Adding abili…

### DIFF
--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -33,13 +33,13 @@ export const tbReducer = (state: ITbState = tbInitialState, action: Actions.Acti
             return { ...state, ...action.payload, isLoading: false };
         }
         case Actions.SET_COLUMNS: {
-            return { ...state, columns: action.payload };
+            return { ...state, page: 0, columns: action.payload };
         }
         case Actions.UPDATE_ITEMS_PER_PAGE: {
             return { ...state, itemsPerPage: action.payload };
         }
         case Actions.UPDATE_SEARCH_TEXT: {
-            return { ...state, searchText: action.payload };
+            return { ...state, page: 0, searchText: action.payload };
         }
         default:
             return state;

--- a/src/types/ITbApi.ts
+++ b/src/types/ITbApi.ts
@@ -4,7 +4,7 @@ export interface ITbApi {
     exportTo: (allRows: boolean, exportFunc: (payload: any[], columns: ColumnModel[]) => void) => void;
     goToPage: (page: number) => void;
     processRequest: () => void;
-    reloadGrid: () => void;
+    reloadGrid: (resetPage?: boolean) => void;
     setColumns: (columns: ColumnModel[]) => void;
     sortColumn: (columnName: string, multiSort?: boolean) => void;
     updateItemsPerPage: (itemsPerPage: number) => void;

--- a/test/components/tubularComponent.tsx
+++ b/test/components/tubularComponent.tsx
@@ -11,6 +11,7 @@ export const TubularComponent = () => {
                 <button onClick={() => api.goToPage(state.page + 1)}>Go to next page</button>
                 <button onClick={() => api.goToPage(state.page - 1)}>Go to previous page</button>
                 <button onClick={() => api.sortColumn('CustomerName')}>Sort by Customer Name</button>
+                <button onClick={() => api.reloadGrid(true)}>Refresh</button>
             </div>
             {!state.isLoading && (
                 <table>

--- a/test/useTubular.spec.tsx
+++ b/test/useTubular.spec.tsx
@@ -115,6 +115,19 @@ describe('Sorting', () => {
         expect(getLocalDataSourceSpy).toHaveBeenCalledTimes(1);
     });
 
+    it('should reload the grid', async () => {
+        const refreshBtn = sut.getByText('Refresh');
+
+        fireEvent.click(refreshBtn);
+        await waitFor(() => expect(queryByRole(sut.container, 'table')).toBeDefined());
+
+        const rows = sut.queryAllByRole('row');
+        expect(rows).toHaveLength(10);
+
+        expectFirstPage(rows);
+        expect(getLocalDataSourceSpy).toHaveBeenCalledTimes(2);
+    });
+
     describe('Sorting Asc & Desc', () => {
         it('should sort by CustomerName ASC', async () => {
             const sortBtn = sut.getByText('Sort by Customer Name');


### PR DESCRIPTION
Search and Changes on columns will cause resetting page. Adding ability to reload grid and reset the page while doing it.

I'm doing this because Search and Changes on columns should not just reload, but the grid should reset to initial page since the entire grid is changed.

The ability to reload the grid and reset the page will be handy for tubular fabric, where we need to reload the grid and we need to also fallback to page 0. 